### PR TITLE
팔로우 서비스 분리하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,20 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {
@@ -45,3 +53,22 @@ dependencyManagement {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:latest
+    restart: always
+    ports:
+      - "3310:3306"
+    volumes:
+      - ./mysql:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER_NAME}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: 'Asia/Seoul'

--- a/src/main/java/com/hanghae/followservice/FollowServiceApplication.java
+++ b/src/main/java/com/hanghae/followservice/FollowServiceApplication.java
@@ -3,6 +3,8 @@ package com.hanghae.followservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableDiscoveryClient
@@ -12,4 +14,8 @@ public class FollowServiceMsaApplication {
         SpringApplication.run(FollowServiceMsaApplication.class, args);
     }
 
+    @Bean
+    public RestTemplate getRestTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/com/hanghae/followservice/FollowServiceApplication.java
+++ b/src/main/java/com/hanghae/followservice/FollowServiceApplication.java
@@ -8,10 +8,10 @@ import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableDiscoveryClient
-public class FollowServiceMsaApplication {
+public class FollowServiceApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(FollowServiceMsaApplication.class, args);
+        SpringApplication.run(FollowServiceApplication.class, args);
     }
 
     @Bean

--- a/src/main/java/com/hanghae/followservice/controller/FollowController.java
+++ b/src/main/java/com/hanghae/followservice/controller/FollowController.java
@@ -1,0 +1,26 @@
+package com.hanghae.followservice.controller;
+
+import com.hanghae.followservice.dto.request.FollowRequest;
+import com.hanghae.followservice.dto.response.Response;
+import com.hanghae.followservice.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/follow-service")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/follow")
+    public Response<Void> follow(FollowRequest request, @RequestHeader HttpHeaders headers) {
+        followService.follow(request.toUser(), headers);
+        return Response.success(null);
+    }
+}
+

--- a/src/main/java/com/hanghae/followservice/domain/constant/ErrorCode.java
+++ b/src/main/java/com/hanghae/followservice/domain/constant/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.hanghae.followservice.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not founded");
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/hanghae/followservice/domain/entity/Follow.java
+++ b/src/main/java/com/hanghae/followservice/domain/entity/Follow.java
@@ -1,0 +1,27 @@
+package com.hanghae.followservice.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "from_user_id", nullable = false)
+    private String fromUser;
+
+    @Column(name = "to_user_id", nullable = false)
+    private String toUser;
+
+    public static Follow of(String fromUser, String toUser){
+        Follow follow = new Follow();
+        follow.setFromUser(fromUser);
+        follow.setToUser(toUser);
+        return follow;
+    }
+}

--- a/src/main/java/com/hanghae/followservice/domain/repository/FollowRepository.java
+++ b/src/main/java/com/hanghae/followservice/domain/repository/FollowRepository.java
@@ -1,0 +1,11 @@
+package com.hanghae.followservice.domain.repository;
+
+import com.hanghae.followservice.domain.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Optional<Follow> findByFromUser(String fromUser);
+    Optional<Follow> findByFromUserAndToUser(String fromUser, String ToUser);
+}

--- a/src/main/java/com/hanghae/followservice/dto/request/FollowRequest.java
+++ b/src/main/java/com/hanghae/followservice/dto/request/FollowRequest.java
@@ -1,0 +1,6 @@
+package com.hanghae.followservice.dto.request;
+
+public record FollowRequest(
+        String toUser
+) {
+}

--- a/src/main/java/com/hanghae/followservice/dto/response/Response.java
+++ b/src/main/java/com/hanghae/followservice/dto/response/Response.java
@@ -1,0 +1,36 @@
+package com.hanghae.followservice.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Response<T> {
+    private String status;
+    private T result;
+
+    public static <T> Response<T> success() {
+        return new Response<T>("SUCCESS", null);
+    }
+
+    public static <T> Response<T> success(T result) {
+        return new Response<T>("SUCCESS", result);
+    }
+
+    public static Response<Void> error(String resultCode) {
+        return new Response<Void>(resultCode, null);
+    }
+
+    public String toStream() {
+        if (result == null) {
+            return "{" +
+                    "\"status\":" + "\"" + status + "\"," +
+                    "\"result\":" + null +
+                    "}";
+        }
+        return "{" +
+                "\"status\":" + "\"" + status + "\"," +
+                "\"result\":" + "\"" + result + "\"," +
+                "}";
+    }
+}

--- a/src/main/java/com/hanghae/followservice/exception/FollowServiceApplicationException.java
+++ b/src/main/java/com/hanghae/followservice/exception/FollowServiceApplicationException.java
@@ -1,0 +1,27 @@
+package com.hanghae.followservice.exception;
+
+import com.hanghae.followservice.domain.constant.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowServiceApplicationException extends RuntimeException {
+
+    private ErrorCode errorCode;
+    private String message;
+
+    public FollowServiceApplicationException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+    }
+
+    public FollowServiceApplicationException() {
+
+    }
+
+    @Override
+    public String getMessage() {
+        return (message == null) ? errorCode.getMessage() : String.format("%s. %s", errorCode.getMessage(), message);
+    }
+}

--- a/src/main/java/com/hanghae/followservice/service/FollowService.java
+++ b/src/main/java/com/hanghae/followservice/service/FollowService.java
@@ -1,0 +1,47 @@
+package com.hanghae.followservice.service;
+
+import com.hanghae.followservice.domain.constant.ErrorCode;
+import com.hanghae.followservice.domain.entity.Follow;
+import com.hanghae.followservice.domain.repository.FollowRepository;
+import com.hanghae.followservice.dto.response.Response;
+import com.hanghae.followservice.exception.FollowServiceApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final RestTemplate restTemplate;
+    private final FollowRepository followRepository;
+
+    public void follow(String toUser, HttpHeaders headers) {
+        String userAccountUrl = "http://127.0.0.1:8000/user-service/users/email";
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // USER-SERVICE API 호출하여 이메일 정보 가져오기 유저서비스의 반환타입
+        ResponseEntity<String> userEmailResponse =
+                restTemplate.exchange(userAccountUrl, HttpMethod.GET, entity,
+                        String.class);
+
+        String fromUser = userEmailResponse.getBody();
+
+        Optional<Follow> existingFollow = followRepository.findByFromUserAndToUser(fromUser, toUser);
+
+        if (existingFollow.isPresent()) {
+            followRepository.delete(existingFollow.get());
+        } else {
+            followRepository.save(Follow.of(fromUser, toUser));
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,9 +1,30 @@
 server:
   port: 0
 
+debug: false
+management.endpoints.web.exposure.include: "*"
+
+logging:
+  level:
+    com.hanghae.followservice: debug
+    org.springframework.web.servlet: debug
+    org.springframework.transaction.interceptor: trace
+    org.hibernate.type.descriptor.sql: trace
+
 spring:
   application:
     name: follow-service
+
+  jpa:
+    defer-datasource-initialization: true
+    hibernate.ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate.format_sql: true
+      hibernate.default_batch_fetch_size: 100
+
+  h2.console.enabled: false
+  sql.init.mode: always
 
 eureka:
   instance:


### PR DESCRIPTION
이 pr은 팔로우 서비스를 분리하고 유저 서비스와 팔로우 서비스를 연결시키는 로직을 포함한다.

[고민했던 부분]
기존의 모놀리스 서비스에서는 Jwt토큰을 활용하여 현재 로그인 된 유저 이메일을 쉽게 알 수 있었고 팔로우 정보를 저장시킬때 팔로우 하려는 사람 Id만 파라미터로 보내주면 관계가 DB에 저장되었다. 하지만 팔로우 서비스를 분리하려고 보니 Follow 엔티티는 유저 엔티티와 의존하고 있는 상황이였다. "Follow 서비스에서 UserEntity의 정보를 어떻게 가져올 수 있을까?" 어려움에 직면했다. 대안책으로 UserAccount와 Join하여 사용되는 Follow 엔티티의 `FromUser`와 `ToUser`의 필드 타입을 `String` 타입으로 수정했다. 생각의 흐름은 다음과 같다.

1. `User-Service` 에서 Login을 하면 JwtToken이 발행된다.
2. `Follow-Service`에서 User정보를 사용하기 위해선 `Rest API`가 필요하다 여기서 말하는 Rest API의 의미는 마이크로 서비스간 통신을 할때 사용되는 `Rest API`이다. `RestTemplate`을 사용했다.
3. `Follow-Service` 인스턴스의 요청을 보낸다. 이때 API 요청을 관리하는 API GateWay를 통해 라우팅 된다.
4. `Follow-Service`의 follow 서비스 메서드가 호출된다. (중요)

4번 과정이 중요하다

follow 서비스 메서드가 호출 될때는 User정보가 필요한 시점이다. RestTemplate을 통해 User-Service와 통신을 해야만 한다. 그럼 어떻게 User정보를 알수있을까?? 이때 아까 로그인해서 발행받은 Jwt토큰을 함께 보내주면된다. 그러면 User-Service에서는 해당 토큰으로 인증이 확인되고 
UserController의 getEmail 메서드를 통해 로그인 된 유저 즉 본인의 이메일 정보를 반환 받을 수 있다.

해당 어려움을 해결하기 위해서 기존 구축했던 서비스 플로우를 잘 이해해야했다. 
약간 아쉬운 부분은 테이블 간의 관계를 끊어서 문제 해결을 했다는 점인데, 분리된 마이크로 서비스에서 테이블 간의 관계를 유지하면서 필요한 정보를 받아올 수 있는 방법에 대해서 생각하고 고민해봐야 겠다..